### PR TITLE
build.gradle corrigido

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,10 +20,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator' //SPRING ACTUATOR
     developmentOnly 'org.springframework.boot:spring-boot-devtools' //SPRING DEV-TOOLS
     runtimeOnly 'io.r2dbc:r2dbc-postgresql' //R2DBC POSTGRESQL DRIVER
-    implementation 'org.springdoc:springdoc-openapi-webflux-ui' //SPRINGDOC OPENAPI WEBFLUX
+    implementation 'org.springdoc:springdoc-openapi-webflux-ui:1.6.15' //SPRINGDOC OPENAPI WEBFLUX
     compileOnly 'org.projectlombok:lombok' //LOMBOK
     annotationProcessor 'org.projectlombok:lombok' //LOMBOK
-    implementation 'org.modelmapper:modelmapper' //MODELMAPPER
+    implementation 'org.modelmapper:modelmapper:3.1.1' //MODELMAPPER
     testImplementation 'org.springframework.boot:spring-boot-starter-test' //SPRING TEST
     testImplementation 'org.springframework.security:spring-security-test' //SPRING SECURITY TEST
     testImplementation 'io.projectreactor:reactor-test' //REACTOR TEST


### PR DESCRIPTION
Corrigido conflito durante o build do projeto gerado pela omissão da versão de algumas dependências.

As versões das dependências `org.springdoc:springdoc-openapi-webflux-ui` e `org.modelmapper:modelmapper` agora estão explicitamente declaradas no `build.gradle`.